### PR TITLE
Changing git repository path to cloud-heroku-api-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cloud-heroku-microgateway
+# WSO2 API Gateway
 
 ## Deploy on Heroku
 
@@ -7,7 +7,7 @@ The ‘Deploy to Heroku’ button enables users to deploy WSO2 API Gateway on He
 
 Try WSO2 API Gateway with direct deployment on Heroku:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/NipunaPrashan/heroku.git/tree/master)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/wso2/cloud-heroku-api-gateway/tree/master)
 
 ## Documentation
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "WSO2 API Gateway",
   "description": "Deploy your WSO2 API Gateway on Heroku",
-  "repository": "https://github.com/wso2/cloud-heroku-microgateway.git",
+  "repository": "https://github.com/wso2/cloud-heroku-api-gateway.git",
   "logo": "https://s3.amazonaws.com/wso2cloud-resources/images/api_cloud_logo.png",
   "keywords": ["wso2", "api-gateway", "on-prem", "hybrid-cloud", "cloud", "api-management", "hybrid-api-management"],
   "env": {


### PR DESCRIPTION
## Purpose
> Change the repository path Microgateway to API gateway.

## Goals
> WSO2 API gateway can be deployed on Heroku as a dyno. API Gateway is the proper suitable name for the Heroku button. Also, this will help users to find the add-on easily.

## Approach
> Renaming repository name.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 -N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/cloud-heroku-api-gateway/pull/3

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A