### PR TITLE
Adding Heroku buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ Try WSO2 API Gateway with direct deployment on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/wso2/cloud-heroku-api-gateway/tree/master)
 
+## Heroku buildpack: WSO2 API Gateway
+
+To use WSO2 API Gateway buildpack with heroku:
+
+1. Set up your app to [deploy to heroku with git](https://devcenter.heroku.com/articles/git).
+2. Set this repository as the buildpack URL:
+   
+        heroku buildpacks:set https://github.com/wso2/cloud-heroku-api-gateway.git
+3. Add the WSO2 API Cloud addon: 
+        
+        heroku addons:create wso2apicloud:<plan>
+4. Set WSO2_CLOUD_EMAIL, WSO2_CLOUD_PASSWORD, WSO2_CLOUD_ORG_KEY environment variables. This is required for setting 
+up the API Gateway.
+
+        heroku config:set WSO2_CLOUD_EMAIL=<Your WSO2 Cloud account email>
+        heroku config:set WSO2_CLOUD_PASSWORD=<Your WSO2 Cloud account password>
+        heroku config:set WSO2_CLOUD_ORG_KEY=<Your WSO2 Cloud organization key>
+
+5. Once that's done, you can deploy your app using this build pack any time by pushing to heroku:
+
+        git push heroku master
+        
+6. Finally, you need to scale your application with enough memory to run the API Gateway.
+        
+        heroku ps:scale web=1:standard-2x
 ## Documentation
 
 For more information about WSO2 API Gateway, see these WSO2 documentations:

--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ up the API Gateway.
 
 For more information about WSO2 API Gateway, see these WSO2 documentations:
 
+- [WSO2 API Cloud](https://wso2.com/api-management/cloud/)
 - [Working with Hybrid API Management](https://docs.wso2.com/display/APICloud/Working+with+Hybrid+API+Management)
 - [WSO2 Cloud Blog](https://wso2.com/blogs/cloud/going-hybrid-on-premises-api-gateways/)

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# fail fast
+set -e
+
+BP_DIR=$(cd $(dirname $0)/..; pwd) # absolute path
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
+
+source $BP_DIR/lib/common.sh
+source $BP_DIR/lib/maven.sh
+source <(curl -s --retry 3 -L $BUILDPACK_STDLIB_URL)
+
+export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
+
+# Install Java
+install_jdk ${BUILD_DIR}
+
+[ -n "$(find ${BUILD_DIR} -type f -name "*.kt")" ] && mcount "kotlin.source"
+[ -n "$(find ${BUILD_DIR} -type f -name "*.groovy")" ] && mcount "groovy.source"
+
+if has_maven_wrapper $BUILD_DIR; then
+  cache_copy ".m2/wrapper" $BUILD_DIR $CACHE_DIR
+  rm -rf $BUILD_DIR/.m2
+fi
+
+# Build pom file
+run_mvn "compile" $BP_DIR $CACHE_DIR
+
+# Copy Procfile and the configure-gateway.sh file into build directory
+cp "Procfile" "$BUILD_DIR"
+cp "configure-gateway.sh" "$BUILD_DIR"

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+echo "Java"
+exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+cat << EOF
+---
+addons:
+  - wso2apicloud
+EOF

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+export DEFAULT_MAVEN_VERSION="3.3.9"
+export BUILDPACK_STDLIB_URL="https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh"
+
+install_maven() {
+  local installDir=$1
+  local buildDir=$2
+  mavenHome=$installDir/.maven
+
+  definedMavenVersion=$(detect_maven_version $buildDir)
+
+  mavenVersion=${definedMavenVersion:-$DEFAULT_MAVEN_VERSION}
+  mcount "mvn.version.${mavenVersion}"
+
+  status_pending "Installing Maven ${mavenVersion}"
+  if is_supported_maven_version ${mavenVersion}; then
+    mavenUrl="https://lang-jvm.s3.amazonaws.com/maven-${mavenVersion}.tar.gz"
+    download_maven ${mavenUrl} ${installDir} ${mavenHome}
+    status_done
+  else
+    error_return "Error, you have defined an unsupported Maven version in the system.properties file.
+The default supported version is ${DEFAULT_MAVEN_VERSION}"
+    return 1
+  fi
+}
+
+download_maven() {
+  local mavenUrl=$1
+  local installDir=$2
+  local mavenHome=$3
+  rm -rf $mavenHome
+  curl --retry 3 --silent --max-time 60 --location ${mavenUrl} | tar xzm -C $installDir
+  chmod +x $mavenHome/bin/mvn
+}
+
+is_supported_maven_version() {
+  local mavenVersion=${1}
+  if [ "$mavenVersion" = "$DEFAULT_MAVEN_VERSION" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.2.5" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.2.3" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.1.1" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.0.5" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+detect_maven_version() {
+  local baseDir=${1}
+  if [ -f ${baseDir}/system.properties ]; then
+    mavenVersion=$(get_app_system_value ${baseDir}/system.properties "maven.version")
+    if [ -n "$mavenVersion" ]; then
+      echo $mavenVersion
+    else
+      echo ""
+    fi
+  else
+    echo ""
+  fi
+}
+
+get_app_system_value() {
+  local file=${1?"No file specified"}
+  local key=${2?"No key specified"}
+
+  # escape for regex
+  local escaped_key=$(echo $key | sed "s/\./\\\./g")
+
+  [ -f $file ] && \
+  grep -E ^$escaped_key[[:space:]=]+ $file | \
+  sed -E -e "s/$escaped_key([\ \t]*=[\ \t]*|[\ \t]+)([A-Za-z0-9\.-]*).*/\2/g"
+}
+
+cache_copy() {
+  rel_dir=$1
+  from_dir=$2
+  to_dir=$3
+  rm -rf "${to_dir:?}/${rel_dir:?}"
+  if [ -d $from_dir/$rel_dir ]; then
+    mkdir -p $to_dir/$rel_dir
+    cp -pr $from_dir/$rel_dir/. $to_dir/$rel_dir
+  fi
+}
+
+install_jdk() {
+  local install_dir=${1}
+
+  let start=$(nowms)
+  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz}
+  mkdir -p /tmp/jvm-common
+  curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+  source /tmp/jvm-common/bin/util
+  source /tmp/jvm-common/bin/java
+  source /tmp/jvm-common/opt/jdbc.sh
+  mtime "jvm-common.install.time" "${start}"
+
+  let start=$(nowms)
+  install_java_with_overlay ${install_dir}
+  mtime "jvm.install.time" "${start}"
+}

--- a/lib/maven.sh
+++ b/lib/maven.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+_mvn_java_opts() {
+  local scope=${1}
+  local home=${2}
+  local cache=${3}
+
+  echo -n "-Xmx1024m"
+  if [ "$scope" = "compile" ]; then
+    echo -n " $MAVEN_JAVA_OPTS"
+  elif [ "$scope" = "test-compile" ]; then
+    echo -n ""
+  fi
+
+  echo -n " -Duser.home=$home -Dmaven.repo.local=$cache/.m2/repository"
+}
+
+_mvn_cmd_opts() {
+  local scope=${1}
+
+  if [ "$scope" = "compile" ]; then
+    echo -n "${MAVEN_CUSTOM_OPTS:-"-DskipTests"}"
+    echo -n " ${MAVEN_CUSTOM_GOALS:-"clean dependency:list install"}"
+  elif [ "$scope" = "test-compile" ]; then
+    echo -n "${MAVEN_CUSTOM_GOALS:-"clean dependency:resolve-plugins test-compile"}"
+  else
+    echo -n ""
+  fi
+}
+
+_mvn_settings_opt() {
+  local home="${1}"
+  local mavenInstallDir="${2}"
+
+  if [ -n "$MAVEN_SETTINGS_PATH" ]; then
+    mcount "mvn.settings.path"
+    echo -n "-s $MAVEN_SETTINGS_PATH"
+  elif [ -n "$MAVEN_SETTINGS_URL" ]; then
+    mkdir -p ${mavenInstallDir}/.m2
+    curl --retry 3 --silent --max-time 10 --location $MAVEN_SETTINGS_URL --output ${mavenInstallDir}/.m2/settings.xml
+    mcount "mvn.settings.url"
+    echo -n "-s ${mavenInstallDir}/.m2/settings.xml"
+  elif [ -f ${home}/settings.xml ]; then
+    mcount "mvn.settings.file"
+    echo -n "-s ${home}/settings.xml"
+  else
+    mcount "mvn.settings.default"
+    echo -n ""
+  fi
+}
+
+has_maven_wrapper() {
+  local home=${1}
+  if [ -f $home/mvnw ] &&
+      [ -f $home/.mvn/wrapper/maven-wrapper.jar ] &&
+      [ -f $home/.mvn/wrapper/maven-wrapper.properties ] &&
+      [ -z "$(detect_maven_version $home)" ]; then
+    return 0;
+  else
+    return 1;
+  fi
+}
+
+get_cache_status() {
+  local cacheDir=${1}
+  if [ ! -d ${cacheDir}/.m2 ]; then
+    echo "not-found"
+  else
+    echo "valid"
+  fi
+}
+
+run_mvn() {
+  local scope=${1}
+  local home=${2}
+  local mavenInstallDir=${3}
+
+  mkdir -p ${mavenInstallDir}
+  if has_maven_wrapper $home; then
+    cache_copy ".m2/wrapper" $mavenInstallDir $home
+    chmod +x $home/mvnw
+    local mavenExe="./mvnw"
+    mcount "mvn.version.wrapper"
+  else
+    cd $mavenInstallDir
+    let start=$(nowms)
+    install_maven ${mavenInstallDir} ${home}
+    mtime "mvn.${scope}.time" "${start}"
+    PATH="${mavenInstallDir}/.maven/bin:$PATH"
+    local mavenExe="mvn"
+    cd $home
+  fi
+
+  local mvn_settings_opt="$(_mvn_settings_opt ${home} ${mavenInstallDir})"
+
+  export MAVEN_OPTS="$(_mvn_java_opts ${scope} ${home} ${mavenInstallDir})"
+
+  cd $home
+  local mvnOpts="$(_mvn_cmd_opts ${scope})"
+  status "Executing: ${mavenExe} ${mvnOpts}"
+
+  local cache_status="$(get_cache_status ${mavenInstallDir})"
+  let start=$(nowms)
+  ${mavenExe} -DoutputFile=target/mvn-dependency-list.log -B ${mvn_settings_opt} ${mvnOpts} | indent
+
+  if [ "${PIPESTATUS[*]}" != "0 0" ]; then
+    error "Failed to build app with Maven
+We're sorry this build is failing! If you can't find the issue in application code,
+please submit a ticket so we can help: https://help.heroku.com/"
+  fi
+
+  mtime "mvn.${scope}.time" "${start}"
+  mtime "mvn.${scope}.time.cache.${cache_status}" "${start}"
+}
+
+write_mvn_profile() {
+  local home=${1}
+  local mvnBinDir=${home}/.maven/bin
+  mkdir -p ${home}/.profile.d
+  cat << EOF > ${home}/.profile.d/maven.sh
+export M2_HOME="${home}/.maven"
+export MAVEN_OPTS="$(_mvn_java_opts "test" ${home} ${home})"
+export PATH="${mvnBinDir}:\$PATH"
+EOF
+}


### PR DESCRIPTION
## Purpose
> The purpose is to enable users to add WSO2 API Gateway as a Heroku buildpack.

## Goals
> Now, the users can deploy WSO2 API Gateway using the Heroku button and the Heroku buildpack.

## Approach
> Adding required Buildpack API files.

## User stories
> N/A

## Release note
>N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8
 
## Learning
> N/A